### PR TITLE
fix：修复小屏幕的情况下,右边个人信息益出问题

### DIFF
--- a/client/src/layouts/AppMain.vue
+++ b/client/src/layouts/AppMain.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="xl:max-w-screen-xl relative m-auto mt-20">
+  <div class="md:flex md:justify-between xl:max-w-screen-xl relative m-auto mt-20">
     <div class="w-[950px] max-w-full relative">
       <nuxt keep-alive />
     </div>
-    <div class="absolute top-0 right-0 w-[19rem] hidden xl:block">
+    <div class="sticky top-0 right-0 w-[19rem] hidden xl:block">
       <SideInfo />
     </div>
   </div>


### PR DESCRIPTION
由于你使用absolute定位方式,无法根据盒模型高度来判定；

改成 sticky 定位就可以达到良好的效果。
并且让他们flex布局，更友好的管理布局页面

如看见pr，请在您本地测试跑过一次，再合并。谢谢